### PR TITLE
Add "prevent_destroy" lifecycle rule

### DIFF
--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -12,6 +12,9 @@ resource "aws_secretsmanager_secret" "default" {
   recovery_window_in_days = each.value.recovery_window_in_days
   tags                    = merge({ "Name" = each.key }, var.tags)
 
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 locals {

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -29,8 +29,8 @@ variable "service" {
 
 variable "tags" {
   description = "Tags to be applied to resources where supported"
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 # Debugging.


### PR DESCRIPTION
Add "prevent_destroy" lifecycle rule to prevent accidental destruction of secrets that may be difficult or time-consuming to re-create.